### PR TITLE
Adding clustering 5 models inside single_model_dict #32

### DIFF
--- a/tab_automl/automl/models.py
+++ b/tab_automl/automl/models.py
@@ -9,7 +9,11 @@ from sklearn.svm import SVR
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.neighbors import KNeighborsRegressor
-
+from sklearn.cluster import AffinityPropagation
+from sklearn.cluster import AgglomerativeClustering
+from sklearn.cluster import Birch
+from sklearn.cluster import DBSCAN
+from sklearn.cluster import KMeans
 
 single_model_dict = {
     "regression": {
@@ -26,5 +30,12 @@ single_model_dict = {
         "Random Forest Classifier": RandomForestClassifier,
         "XGBoost Classifier": XGBClassifier,
         "KNN Classifier": KNeighborsClassifier
+    },
+    "clustering":{
+        "Affinity Propagation":AffinityPropagation,
+        "Agglomerative Clustering":AgglomerativeClustering,
+        "Birch":Birch,
+        "DBSCAN":DBSCAN,
+        "KMeans":KMeans
     }
 }

--- a/tab_automl/automl/models.py
+++ b/tab_automl/automl/models.py
@@ -31,11 +31,11 @@ single_model_dict = {
         "XGBoost Classifier": XGBClassifier,
         "KNN Classifier": KNeighborsClassifier
     },
-    "clustering":{
-        "Affinity Propagation":AffinityPropagation,
-        "Agglomerative Clustering":AgglomerativeClustering,
-        "Birch":Birch,
-        "DBSCAN":DBSCAN,
-        "KMeans":KMeans
+    "clustering": {
+        "Affinity Propagation": AffinityPropagation,
+        "Agglomerative Clustering": AgglomerativeClustering,
+        "Birch": Birch,
+        "DBSCAN": DBSCAN,
+        "KMeans": KMeans
     }
 }


### PR DESCRIPTION
PR tagged with #32 

I have added 5 clustering models in automl -> models.py .
Name of the clustering models are as follows:
AffinityPropagation
AgglomerativeClustering
Birch
DBSCAN
KMeans
.
DESCRIPTION
AffinityPropagation - It involves finding a set of exemplars that best summarize the data. It takes as input measures of similarity between pairs of data points. Real-valued messages are exchanged between data points until a high-quality set of exemplars and corresponding clusters gradually emerges
.
AgglomerativeClustering- It involves merging examples until the desired number of clusters is achieved.It is implemented via the class AgglomerativeClustering and the main configuration to tune is the “n_clusters” set, an estimate of the number of clusters in the data, e.g. 2.
.
BIRCH -BIRCH Clustering involves constructing a tree structure from which cluster centroids are extracted.
main configuration to tune is the “threshold” and “n_clusters” hyperparameters, the latter of which provides an estimate of the number of clusters.
.
DBSCAN Clustering  involves finding high-density areas in the domain and expanding those areas of the feature space around them as clusters.
the main configuration to tune is the “eps” and “min_samples” hyperparameters.
.
KMEANS -the main configuration to tune is the “n_clusters” hyperparameter set to the estimated number of clusters in the data.