### PR TITLE
[Issue {#32}]Add clustering models inside single_model_dict 

### DIFF
--- a/tab_automl/automl/models.py
+++ b/tab_automl/automl/models.py
@@ -14,6 +14,11 @@ from sklearn.cluster import AgglomerativeClustering
 from sklearn.cluster import Birch
 from sklearn.cluster import DBSCAN
 from sklearn.cluster import KMeans
+from sklearn.cluster import MiniBatchKMeans
+from sklearn.cluster import MeanShift
+from sklearn.cluster import OPTICS
+from sklearn.cluster import SpectralClustering
+from sklearn.mixture import GaussianMixture
 
 single_model_dict = {
     "regression": {
@@ -36,6 +41,11 @@ single_model_dict = {
         "Agglomerative Clustering": AgglomerativeClustering,
         "Birch": Birch,
         "DBSCAN": DBSCAN,
-        "KMeans": KMeans
+        "KMeans": KMeans,
+        "MiniBatchKMeans": MiniBatchKMeans,
+        "MeanShift": MeanShift,
+        "OPTICS": OPTICS,
+        "SpectralClustering": SpectralClustering,
+        "GaussianMixture": GaussianMixture
     }
 }


### PR DESCRIPTION
This PR fixes for issue [#32](https://github.com/sagnik1511/Tabular-AutoML/issues/32)

### Changes made

Added 5 new clustering models in models.py

### Reason

**Mini-Batch K-Means**
Mini-Batch K-Means is a modified version of k-means that makes updates to the cluster centroids using mini-batches of samples rather than the entire dataset, which can make it faster for large datasets, and perhaps more robust to statistical noise.
**Mean Shift**
Mean shift clustering involves finding and adapting centroids based on the density of examples in the feature space.
**OPTICS**
OPTICS clustering (where OPTICS is short for Ordering Points To Identify the Clustering Structure) is a modified version of DBSCAN.
**Spectral Clustering**
Spectral Clustering is a general class of clustering methods, drawn from linear algebra. to tune is the n_clusters hyperparameter used to specify the estimated number of clusters in the data.
**Gaussian Mixture Model**
A Gaussian mixture model summarizes a multivariate probability density function with a mixture of Gaussian probability distributions.